### PR TITLE
Added the optional 'nestedGroups' setting for LDAP authentication.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,6 +56,7 @@ class splunk::params (
     'ldap_realnameattribute'    => 'cn',
     'ldap_groupnameattribute'   => 'cn',
     'ldap_groupmemberattribute' => 'member',
+    'ldap_nestedgroups'         => undef,
   }
   $rolemap = {
     'admin'     => 'Domain Admins',

--- a/templates/puppet_common_auth_ldap_base/local/authentication.conf
+++ b/templates/puppet_common_auth_ldap_base/local/authentication.conf
@@ -18,6 +18,9 @@ anonymous_referrals = 0
 userBaseFilter = (objectClass=user)
 userBaseDN = <%= @auth['ldap_userbasedn'] %>
 userNameAttribute = sAMAccountName
+<% if not @auth['ldap_nestedgroups'].nil? -%>
+nestedGroups = <%= @auth['ldap_nestedgroups'] %>
+<% end -%>
 
 [roleMap_ldap_settings]
 <% @rolemap.each_pair do |splunkrole, externalrole| %>


### PR DESCRIPTION
If the option is not set, it is omitted from the authentication.conf file.