### PR TITLE
Fix spacing in server.conf template

### DIFF
--- a/templates/puppet_common_ssl_base/local/server.conf
+++ b/templates/puppet_common_ssl_base/local/server.conf
@@ -8,7 +8,7 @@ dhFile = <%= @splunk_home %>/etc/auth/certs/dhparam.pem
 <%- end -%>
 sslRootCAPath = <%= @splunk_home %>/etc/auth/<%= @sslrootcapath %>
 sslVersions = <%= @sslversions %>
-enableSplunkdSSL=true
+enableSplunkdSSL = true
 <%- if @ecdhcurvename != nil -%>
 ecdhCurveName = <%= @ecdhcurvename %>
 <%- end -%>


### PR DESCRIPTION
Fixes #28 

Adds the spacing around the `=` so that Splunk restarts don't send you into an endless loop of Puppet runs if you subscribe to changes on server.conf.