### PR TITLE
remove extra whitespace from userNameAttribute setting

### DIFF
--- a/templates/puppet_common_auth_ldap_base/local/authentication.conf
+++ b/templates/puppet_common_auth_ldap_base/local/authentication.conf
@@ -43,9 +43,9 @@ userBaseFilter = <%= @auth['ldap_userbasefilter'] %>
 <% end -%>
 userBaseDN = <%= @auth['ldap_userbasedn'] %>
 <% if @auth['ldap_usernameattribute'].nil? -%>
-userNameAttribute = <%= @auth_defaults['ldap_usernameattribute'] %> 
+userNameAttribute = <%= @auth_defaults['ldap_usernameattribute'] %>
 <% else %>
-userNameAttribute = <%= @auth['ldap_usernameattribute'] %> 
+userNameAttribute = <%= @auth['ldap_usernameattribute'] %>
 <% end -%>
 
 [roleMap_ldap_settings]


### PR DESCRIPTION
Removes a trailing whitespace from userNameAttribute setting in authentication.conf template when configuring LDAP auth.

This was causing an update to this file on every Puppet run as well.