### PR TITLE
Add missing `$` in variable name so that custom package source can be used.

### DIFF
--- a/manifests/installed.pp
+++ b/manifests/installed.pp
@@ -40,7 +40,7 @@ class splunk::installed (
           require     => Package[$package],
           refreshonly => true,
         }
-      } elsif $version == undef and package_source != undef {
+      } elsif $version == undef and $package_source != undef {
         package { $package:
           ensure => installed,
           name   => $package_source,


### PR DESCRIPTION
Hello!

We're evaluating this module against https://github.com/voxpupuli/puppet-splunk for managing Universal Forwarders. This module is used to manage Splunk infrastructure at our University so there's benefit in us using this module. One "feature" in voxpupuli's implementation is the ability to pull packages directly from Splunk rather than maintain a local repository. This module seems to be able to do the same, but there is a typographical error in the conditional that branches when `$version` is `undef` and a custom `package_source` is provided (did you catch it? :grin:). 

This PR simply adds the `$` so that the conditional evaluates as expected.

As an aside: This module seems primarily focused on providing configuration management for Splunk infrastructure. Are there any "gotchas" you would warn a new user of this module about when JUST installing forwarders?