### PR TITLE
add ldap port parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class splunk::params (
     'ldap_groupbasedn'          => undef,
     'ldap_groupbasefilter'      => '(objectclass=group)',
     'ldap_host'                 => undef,
+    'ldap_port'                 => undef,
     'ldap_nestedgroups'         => undef,
     'ldap_realnameattribute'    => 'cn',
     'ldap_sslenabled'           => 1,

--- a/templates/puppet_common_auth_ldap_base/local/authentication.conf
+++ b/templates/puppet_common_auth_ldap_base/local/authentication.conf
@@ -27,6 +27,7 @@ groupNameAttribute = <%= @auth_defaults['ldap_groupnameattribute'] %>
 groupNameAttribute = <%= @auth['ldap_groupnameattribute'] %>
 <% end -%>
 host = <%= @auth['ldap_host'] %>
+port = <%= @auth['ldap_port'] %>
 <% if not @auth['ldap_nestedgroups'].nil? -%>
 nestedGroups = <%= @auth['ldap_nestedgroups'] %>
 <% end -%>


### PR DESCRIPTION
give the possibility to change/edit the ldap port by using the module instead of using the default ldap ports 389 or 636 that are preset by splunk.