### PR TITLE
Puppet.lns cannot parse this kind of key [replication_port://8079]

### DIFF
--- a/manifests/server/general.pp
+++ b/manifests/server/general.pp
@@ -23,10 +23,10 @@ class splunk::server::general (
       # delete pass4SymmKey from [general] in etc/system/local/server.conf,
       # otherwise our pass4SymmKey in the app below will be overruled
       augeas { "${splunk_home}/etc/system/local/server.conf pass4symmkey":
-        lens    => 'Puppet.lns',
+        lens    => 'Splunk.lns',
         incl    => "${splunk_home}/etc/system/local/server.conf",
         changes => [
-          'rm general/pass4SymmKey',
+          'rm target[. = "general"]/pass4SymmKey',
         ],
       }
     }

--- a/manifests/server/shclustering.pp
+++ b/manifests/server/shclustering.pp
@@ -61,10 +61,10 @@ class splunk::server::shclustering (
           # to prevent the SH Deployer from overwriting server specific config
           # directives like mgmt_uri 
           -> augeas { "${splunk_home}/etc/system/local/server.conf/shclustering":
-            lens    => 'Puppet.lns',
+            lens    => 'Splunk.lns',
             incl    => "${splunk_home}/etc/system/local/server.conf",
             changes => [
-              "set shclustering/mgmt_uri https://${::fqdn}:8089",
+              "set target[. = 'shclustering']/mgmt_uri https://${::fqdn}:8089",
             ],
           }
         }


### PR DESCRIPTION
Replication port may be configured in server.conf as documented on
https://docs.splunk.com/Documentation/Splunk/8.2.6/Indexer/Configurepeerswithserverconf
but the presence of this stanza prevents augeas from being able to parse
the file.

The "Splunk.lns" is available in Puppet 5.5, but comes with a
few caveats regarding its usage

https://github.com/hercules-team/augeas/commit/b64ee52dbcc5c5fdfd31f3a6bf13f33d98f2e809

Lens to parse Splunk configuration. Based on IniFile lens, with few
differences:

* Accepts empty value in entry
* Entries without parent section are children of .anon node
