### PR TITLE
Augeas will fail if the section is missing

### DIFF
--- a/manifests/server/shclustering.pp
+++ b/manifests/server/shclustering.pp
@@ -64,6 +64,7 @@ class splunk::server::shclustering (
             lens    => 'Splunk.lns',
             incl    => "${splunk_home}/etc/system/local/server.conf",
             changes => [
+              "set target[. = 'shclustering'] shclustering",
               "set target[. = 'shclustering']/mgmt_uri https://${::fqdn}:8089",
             ],
           }


### PR DESCRIPTION
This is a potential regression introduced in
6e049d43714c898955b6d8e24a8ba612de4f71fd. If the `[shclustering]` is
completely missing from the `server.conf`, this augeas rule will fail to
create it.

Even if it is not a practical regression for a Splunk deployment, it's a
nice to make it complete for the benefit of anyone referring to this
code in the future.
